### PR TITLE
Add the `MultiResolverMatch` object as an attribute on the `multiview` f...

### DIFF
--- a/multiurl.py
+++ b/multiurl.py
@@ -63,4 +63,5 @@ class MultiResolverMatch(object):
                 except self.exceptions:
                     continue
             raise urlresolvers.Resolver404({'tried': self.patterns_matched, 'path': self.path})
+        multiview.multi_resolver_match = self
         return multiview


### PR DESCRIPTION
...unction that is dynamically created at `MultiResolverMatch.func`.

This allows code that inspects `request.resolver_match` to dig deeper and
also inspect the actual (wrapped) `ResolverMatch` objects.

This is needed because Django doesn't use the `MultiResolverMatch` object
directly. It creates a new `ResolverMatch` object derived from the properties
and attributes of the `MultiResolverMatch` object, so we lose access to
`MultiResolverMatch.matches`.

This means that `request.resolver_match` will always appear to be
`multiurl.multiview` with no args or kwargs, which is a problem if you need
to access the view function, or URL args and kwargs for a request.
