### PR TITLE
Fix support for `include()` within `multiurl()`.

### DIFF
--- a/multiurl.py
+++ b/multiurl.py
@@ -39,7 +39,7 @@ class MultiRegexURLResolver(urlresolvers.RegexURLResolver):
                 if sub_match:
                     # Here's the part that's different: instead of returning the
                     # first match, build up a list of all matches.
-                    rm = urlresolvers.ResolverMatch(sub_match.func, sub_match.args, sub_match.kwargs, sub_match.url_name)
+                    rm = urlresolvers.ResolverMatch(sub_match.func, sub_match.args, sub_match.kwargs, sub_match.url_name, self.app_name or sub_match.app_name, [self.namespace] + sub_match.namespaces)
                     matched.append(rm)
                     patterns_matched.append([pattern])
                 tried.append([pattern])

--- a/multiurl.py
+++ b/multiurl.py
@@ -25,17 +25,24 @@ class MultiRegexURLResolver(urlresolvers.RegexURLResolver):
         patterns_matched = []
 
         # This is a simplified version of RegexURLResolver. It doesn't
-        # support a regex prefix, and it doesn't need to handle include(),
-        # so it's simplier, but otherwise this is mostly a copy/paste.
+        # support a regex prefix, but otherwise this is mostly a copy/paste.
         for pattern in self.url_patterns:
-            sub_match = pattern.resolve(path)
-            if sub_match:
-                # Here's the part that's different: instead of returning the
-                # first match, build up a list of all matches.
-                rm = urlresolvers.ResolverMatch(sub_match.func, sub_match.args, sub_match.kwargs, sub_match.url_name)
-                matched.append(rm)
-                patterns_matched.append([pattern])
-            tried.append([pattern])
+            try:
+                sub_match = pattern.resolve(path)
+            except urlresolvers.Resolver404 as e:
+                sub_tried = e.args[0].get('tried')
+                if sub_tried is not None:
+                    tried.extend([[pattern] + t for t in sub_tried])
+                else:
+                    tried.append([pattern])
+            else:
+                if sub_match:
+                    # Here's the part that's different: instead of returning the
+                    # first match, build up a list of all matches.
+                    rm = urlresolvers.ResolverMatch(sub_match.func, sub_match.args, sub_match.kwargs, sub_match.url_name)
+                    matched.append(rm)
+                    patterns_matched.append([pattern])
+                tried.append([pattern])
         if matched:
             return MultiResolverMatch(matched, self._exceptions, patterns_matched, path)
         raise urlresolvers.Resolver404({'tried': tried, 'path': path})


### PR DESCRIPTION
The try/except block was not copied across from `RegexURLResolver`, so while
looping through and attempting to match patterns, a `Resolver404` could be
raised when `pattern` was itself a `RegexURLResolver` (returned by
`include()`) and none of it's patterns matched. This exception would bubble
up and the rest of the patterns would not be tested.