### PR TITLE
Make work with Mezzanine PageMiddleware

### DIFF
--- a/multiurl.py
+++ b/multiurl.py
@@ -56,12 +56,13 @@ class MultiResolverMatch(object):
 
     @property
     def func(self):
-        def multiview(request):
+        def multiview(request, *args, **kwargs):
             for i, match in enumerate(self.matches):
                 try:
+                    match.kwargs = dict(match.kwargs.items() + kwargs.items())
                     return match.func(request, *match.args, **match.kwargs)
                 except self.exceptions:
                     continue
             raise urlresolvers.Resolver404({'tried': self.patterns_matched, 'path': self.path})
-        multiview.multi_resolver_match = self
         return multiview
+


### PR DESCRIPTION
Mezzanine page PageMiddleware app adds some stuff to the context, so the view can determine if there is actually a page, and if that page is a 404. This is just a quick hack to get it working. 