### PR TITLE
set MultiResolverMatch.args to tuple()

### DIFF
--- a/multiurl.py
+++ b/multiurl.py
@@ -49,7 +49,7 @@ class MultiResolverMatch(object):
 
         # Attributes to emulate ResolverMatch
         self.kwargs = {}
-        self.args = []
+        self.args = tuple()
         self.url_name = None
         self.app_name = None
         self.namespaces = []


### PR DESCRIPTION
this change makes this library compatible with django debug toolbar.

Without this fix you get the following error:

```
Traceback (most recent call last):
  File "/Users/jacob/.virtualenvs/gizmag/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 67, in __call__
    return self.application(environ, start_response)
  File "/Users/jacob/.virtualenvs/gizmag/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 206, in __call__
    response = self.get_response(request)
  File "/Users/jacob/.virtualenvs/gizmag/lib/python2.7/site-packages/django/core/handlers/base.py", line 196, in get_response
    response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
  File "/Users/jacob/.virtualenvs/gizmag/lib/python2.7/site-packages/django/core/handlers/base.py", line 231, in handle_uncaught_exception
    return debug.technical_500_response(request, *exc_info)
  File "/Users/jacob/.virtualenvs/gizmag/lib/python2.7/site-packages/django/core/handlers/base.py", line 107, in get_response
    response = middleware_method(request, callback, callback_args, callback_kwargs)
  File "/Users/jacob/.virtualenvs/gizmag/lib/python2.7/site-packages/debug_toolbar/middleware.py", line 73, in process_view
    response = panel.process_view(request, view_func, view_args, view_kwargs)
  File "/Users/jacob/.virtualenvs/gizmag/lib/python2.7/site-packages/debug_toolbar/panels/profiling.py", line 132, in process_view
    args = (request,) + view_args
TypeError: can only concatenate tuple (not "list") to tuple
```