### PR TITLE
Support for django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
     - "2.7"
-    - "3.2"
-    - "3.3"
+    - "3.4"
+    - "3.5"
 install: "pip install -r requirements.txt"
 script: python tests.py
 sudo: false

--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,10 @@ Have you ever wanted multiple views to match to the same URL? Now you can.
 
 You may once have tried something like this::
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         url('/app/(\w+)/$', app.views.people),
         url('/app/(\w+)/$', app.views.place),
-    )
+    ]
 
 However, if you try this, ``/app/san-francisco/`` will only map to
 ``app.views.people``. Raising an ``Http404`` from ``app.views.people`` doesn't
@@ -26,12 +26,12 @@ Well, ``django-multiurl`` solves this problem. Just
 
     from multiurl import multiurl
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         multiurl(
             url('/app/(\w+)/$', app.views.people),
             url('/app/(\w+)/$', app.views.place),
         )
-    )
+    ]
 
 Now in your views, raise ``multiurl.ContinueResolving`` anywhere you'd like
 to break out of the view and keep resolving. For example, here's what
@@ -58,13 +58,13 @@ A few notes to round things out:
   considered "continue" statements. For example, to allow ``Http404``
   exceptions to continue resolving, do this::
 
-        urlpatterns = patterns('',
+        urlpatterns = [
             multiurl(
                 url('/app/(\w+)/$', app.views.people),
                 url('/app/(\w+)/$', app.views.place),
                 catch = (Http404, ContinueResolving)
             )
-        )
+        ]
 
   As you can see, ``catch`` should be a tuple of exceptions. It's probably a
   good idea to always include ``ContinueResolving`` in the tuple.

--- a/multiurl.py
+++ b/multiurl.py
@@ -49,8 +49,9 @@ class MultiResolverMatch(object):
 
         # Attributes to emulate ResolverMatch
         self.kwargs = {}
-        self.args = []
+        self.args = ()
         self.url_name = None
+        self.app_names = []
         self.app_name = None
         self.namespaces = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-django>=1.5
+django>=1.7

--- a/tests.py
+++ b/tests.py
@@ -1,30 +1,30 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.urlresolvers import RegexURLResolver, Resolver404, NoReverseMatch
 from django.http import HttpResponse
-from django.utils import unittest
+import unittest
 from multiurl import multiurl, ContinueResolving
 
 class MultiviewTests(unittest.TestCase):
     def setUp(self):
         # Patterns with a "catch all" view (thing) at the end.
-        self.patterns_catchall = RegexURLResolver('^/', patterns('',
+        self.patterns_catchall = RegexURLResolver('^/', [
             multiurl(
                 url(r'^(\w+)/$', person, name='person'),
                 url(r'^(\w+)/$', place, name='place'),
                 url(r'^(\w+)/$', thing, name='thing'),
             )
-        ))
+        ])
 
         # Patterns with no "catch all" - last view could still raise ContinueResolving.
-        self.patterns_no_fallthrough = RegexURLResolver('^/', patterns('',
+        self.patterns_no_fallthrough = RegexURLResolver('^/', [
             multiurl(
                 url(r'^(\w+)/$', person, name='person'),
                 url(r'^(\w+)/$', place, name='place'),
             )
-        ))
+        ])
 
     def test_resolve_match_first(self):
         m = self.patterns_catchall.resolve('/jane/')

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = {py27,py34,py35}-django{17,18,19}
+envlist = {py27,py34,py35}-django19, {py27,py32,py33,py34,py35}-django18, {py27,py32,py33,py34}-django17
 
 [testenv]
 commands = python tests.py
 basepython =
     py27: python2.7
+    py32: python3.2
+    py33: python3.3
     py34: python3.4
     py35: python3.5
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,47 +1,14 @@
 [tox]
-envlist = py26-django14, py27-django14,
-          py26-django15, py27-django15, py32-django15, py33-django15,
-          py26-django16, py27-django16, py32-django16, py33-django16
+envlist = {py27,py34,py35}-django{17,18,19}
 
 [testenv]
 commands = python tests.py
-
-[testenv:py26-django14]
-basepython = python2.6
-deps = Django==1.4.5
-
-[testenv:py27-django14]
-basepython = python2.7
-deps = Django==1.4.5
-
-[testenv:py26-django15]
-basepython = python2.6
-deps = Django==1.5
-
-[testenv:py27-django15]
-basepython = python2.7
-deps = Django==1.5.1
-
-[testenv:py32-django15]
-basepython = python3.2
-deps = Django==1.5.1
-
-[testenv:py33-django15]
-basepython = python3.3
-deps = Django==1.5.1
-
-[testenv:py26-django16]
-basepython = python2.6
-deps = https://github.com/django/django/archive/master.zip
-
-[testenv:py27-django16]
-basepython = python2.7
-deps = https://github.com/django/django/archive/master.zip
-
-[testenv:py32-django16]
-basepython = python3.2
-deps = https://github.com/django/django/archive/master.zip
-
-[testenv:py33-django16]
-basepython = python3.3
-deps = https://github.com/django/django/archive/master.zip
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+deps=
+    pytest
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10


### PR DESCRIPTION
I have updated the code to support Django 1.9 which is now released.

**I have also dropped support for Django versions no longer officially supported** and updated the tox configuration accordingly.

Regarding the travis suite, there is no way to my knowing to test specific versions of Django against specific versions of Python. Which is a problem since Django 1.7 does not support python 3.5. Hence i have updated the travis suit to only test against Django 1.9 with the python version Django 1.9 support.