### PR TITLE
Add Django2 support

### DIFF
--- a/multiurl.py
+++ b/multiurl.py
@@ -1,6 +1,16 @@
 from __future__ import unicode_literals
 
-from django.core import urlresolvers
+try:
+    from django import urls as urlresolvers
+    from django.urls.resolvers import RegexPattern
+except ImportError:
+    # Fallbacks and mocks for Django 1.*
+    from django.core import urlresolvers
+
+    urlresolvers.URLResolver = urlresolvers.RegexURLResolver
+
+    def RegexPattern(pattern):
+        return pattern
 
 
 class ContinueResolving(Exception):
@@ -12,9 +22,9 @@ def multiurl(*urls, **kwargs):
     return MultiRegexURLResolver(urls, exceptions)
 
 
-class MultiRegexURLResolver(urlresolvers.RegexURLResolver):
+class MultiRegexURLResolver(urlresolvers.URLResolver):
     def __init__(self, urls, exceptions):
-        super(MultiRegexURLResolver, self).__init__('', None)
+        super(MultiRegexURLResolver, self).__init__(RegexPattern(''), None)
         self._urls = urls
         self._exceptions = exceptions
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36}-django110, {py27,py34,py35,py36}-django19, {py27,py32,py33,py34,py35,py36}-django18, {py27,py32,py33,py34}-django17
+envlist = {py34,py35,py36}-django20, {py27,py35,py36}-django110, {py27,py34,py35,py36}-django19, {py27,py32,py33,py34,py35,py36}-django18, {py27,py32,py33,py34}-django17
 
 [testenv]
 commands = python tests.py
@@ -17,3 +17,4 @@ deps=
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
+    django20: Django>=2.0


### PR DESCRIPTION
Django2 have changed url-handling quite a lot.  The module should probably be even more rewritten (renaming the class MultiRegexURLResolver, not using django.conf.urls.url at all etc.).

However I find it hard to do these changes while maintaining Django 1 support. These changes works with Django 1 and 2 and is probably good enough :)