### PR TITLE
Setting `resolver_match` in current request

### DIFF
--- a/multiurl.py
+++ b/multiurl.py
@@ -74,6 +74,8 @@ class MultiResolverMatch(object):
         def multiview(request):
             for i, match in enumerate(self.matches):
                 try:
+                    # Update ResolverMatch in request for later usage
+                    request.resolver_match = match
                     return match.func(request, *match.args, **match.kwargs)
                 except self.exceptions:
                     continue


### PR DESCRIPTION
Hi @raiderrobert 

We're using your multiurl library, thanks for that btw :) While using we ran into the problem of not having the right `request.resolver_match` later. For e.g. reverse the current request url in another language like `url = reverse(match.view_name, kwargs=match.kwargs)`.

My provided fix solves this and I might be wrong but I think it is done similar to how django does this internally, see https://github.com/django/django/blob/bff5ccff7501d7bafb53d6110e311882e716bee5/django/core/handlers/base.py#L102

Tell me if you need more added to this simple pull request :)

Best regards,
Silvan