### PR TITLE
Dropping support for Python 3.5 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
-    - "master"
 
 install:
   - pip install tox-travis python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 
 python:
+    - "3.5"
     - "3.6"
     - "3.7"
+    - "master"
 
 install:
   - pip install tox-travis python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
 
 python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
     - "3.6"
+    - "3.7"
 
 install:
   - pip install tox-travis python-coveralls

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ A few notes to round things out:
 * Reverse URL resolution just works as expected. Name your sub-URLs and then
   reverse your heart out.
 
+
 Contributing
 ------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,6 @@ basepython =
     py36: python3.6
     py36: python3.7
 deps =
-    2.0: Django>=2.0,<2.1
-    2.1: Django>=2.1,<2.2
     2.2: Django>=2.2,<2.3
     master: https://github.com/django/django/archive/master.tar.gz
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 python:
     3.5: py35
     3.6: py36
-    3.6: py37
+    3.7: py37
 
 [testenv]
 commands = python tests.py
@@ -18,7 +18,6 @@ basepython =
     py36: python3.6
     py36: python3.7
 deps =
-    1.11: Django>=1.11,<2.0
     2.0: Django>=2.0,<2.1
     2.1: Django>=2.1,<2.2
     2.2: Django>=2.2,<2.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,27 @@
 [tox]
 args_are_paths = false
 envlist = 
-    py27-{1.11},
-    py34-{1.11,2.0},
-    py35-{1.11,2.0,master},
-    py36-{2.0,master}
-
+    py35-{2.2},
+    py36-{2.2, master}
+    py37-{2.2, master}
 
 [travis]
 python:
-    2.7: py27
+    3.5: py35
     3.6: py36
+    3.6: py37
 
 [testenv]
 commands = python tests.py
 basepython =
-    py27: python2.7
-    py34: python3.4
     py35: python3.5
     py36: python3.6
+    py36: python3.7
 deps =
     1.11: Django>=1.11,<2.0
     2.0: Django>=2.0,<2.1
+    2.1: Django>=2.1,<2.2
+    2.2: Django>=2.2,<2.3
     master: https://github.com/django/django/archive/master.tar.gz
 usedevelop = true
 pip_pre = true


### PR DESCRIPTION
Python 3.5 is failing for new versions of Django: https://travis-ci.org/raiderrobert/django-multiurl/jobs/550953529

Rather than debug what's going on here, I'm going to stop testing Python 3.5 and I'll simply be dropping support for them at this time. I realize that's ahead of Django's schedule, but that's my position at this time.