### PR TITLE
Update multiurl.py

### DIFF
--- a/multiurl.py
+++ b/multiurl.py
@@ -55,7 +55,7 @@ class MultiRegexURLResolver(urlresolvers.URLResolver):
 
 
 class MultiResolverMatch(object):
-    def __init__(self, matches, exceptions, patterns_matched, path, route=None):
+    def __init__(self, matches, exceptions, patterns_matched, path, route=''):
         self.matches = matches
         self.exceptions = exceptions
         self.patterns_matched = patterns_matched


### PR DESCRIPTION
This fix prevent error in `django/urls/resolvers.py:521 in _join_route`. This problem occur when you want use some prefix in urls, for example languages prefix.